### PR TITLE
Fix random number contention bug

### DIFF
--- a/htrace-core/src/test/java/org/htrace/TraceCreator.java
+++ b/htrace-core/src/test/java/org/htrace/TraceCreator.java
@@ -98,9 +98,10 @@ public class TraceCreator {
 
   private void importantWork1() {
     TraceScope cur = Trace.startSpan("important work 1");
+    Random r = new Random();
     try {
-      Thread.sleep((long) (2000 * Math.random()));
-      importantWork2();
+      Thread.sleep((long) (r.nextInt(2000)));
+      importantWork2(r);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } finally {
@@ -108,10 +109,10 @@ public class TraceCreator {
     }
   }
 
-  private void importantWork2() {
+  private void importantWork2(Random r) {
     TraceScope cur = Trace.startSpan("important work 2");
     try {
-      Thread.sleep((long) (2000 * Math.random()));
+      Thread.sleep((long) (r.nextInt(2000)));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } finally {
@@ -122,9 +123,9 @@ public class TraceCreator {
   private class MyRunnable implements Runnable {
     @Override
     public void run() {
+      Random r = new Random();
       try {
         Thread.sleep(750);
-        Random r = new Random();
         int importantNumber = 100 / r.nextInt(3);
         System.out.println("Important number: " + importantNumber);
       } catch (InterruptedException ie) {
@@ -132,7 +133,7 @@ public class TraceCreator {
       } catch (ArithmeticException ae) {
         TraceScope c = Trace.startSpan("dealing with arithmetic exception.");
         try {
-          Thread.sleep((long) (3000 * Math.random()));
+          Thread.sleep((long) (r.nextInt(3000)));
         } catch (InterruptedException ie1) {
           Thread.currentThread().interrupt();
         } finally {


### PR DESCRIPTION
Hi, we know that you have migrated the repository, but as there is a code change so we still make a PR here, hope you can understand and we would appreciate your help.  
In TraceCreator.java, Math.random() is used for random number generation. 
According to [Java API ](Link: http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#random--), it's suggested that each thread has their own random number generator to reduce contention. This pull request improved the condition by replacing Math.random() with Random.nextInt().